### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ This is an example of a Supervisor configuration. Add it to your Supervisor conf
 ```
 [program:mygearman]
 command=php /path/to/vendor/bin/gearman start --daemon=false
+process_name=%(program_name)s-procnum-%(process_num)s
 numprocs=12
 autostart=true
 autorestart=true


### PR DESCRIPTION
Added the following to the Supervisord configuration example:

process_name=%(program_name)s-procnum-%(process_num)s

As per Supervisord configuration the process_name is required:

http://supervisord.org/configuration.html#program-x-section-example
> numprocs:
> Supervisor will start as many instances of this program as named by numprocs. Note that if numprocs > 1, the process_name expression must include %(process_num)s (or any other valid Python string expression that includes process_num) within it.