### PR TITLE
allow console 3.4.* to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-gearman": "*",
         "psr/log": "~1",
         "react/event-loop": "0.4.*",
-        "symfony/console": "2.*"
+        "symfony/console": "2.*|3.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
Hey, console 2.* dependency is unmaintained and causing dependency hell in my repository. Your lib works fine with 3.4.